### PR TITLE
2-fix-pdf-view-mode to show branch

### DIFF
--- a/nano-modeline.el
+++ b/nano-modeline.el
@@ -260,22 +260,22 @@
   (derived-mode-p 'pdf-view-mode))
 
 (defun nano-modeline-pdf-view-mode ()
-      (let ((buffer-name (format-mode-line "%b"))
-	    (mode-name   (format-mode-line "%m"))
-	    (branch      (vc-branch))
-	    (page-number (concat
-			  (number-to-string (pdf-view-current-page)) "/"
-			  (or (ignore-errors
-				(number-to-string (pdf-cache-number-of-pages)))
-			      "???"))))
-	(nano-modeline-compose
-	 "RW"
-	 buffer-name
-	 (concat "(" mode-name
-		 (if branch (concat ", "
-				    (propertize branch 'face 'italic)))
-		 ")" )
-	 page-number)))
+  (let ((buffer-name (format-mode-line "%b"))
+	(mode-name   (format-mode-line "%m"))
+	(branch      (vc-branch))
+	(page-number (concat
+		      (number-to-string (pdf-view-current-page)) "/"
+		      (or (ignore-errors
+			    (number-to-string (pdf-cache-number-of-pages)))
+			  "???"))))
+    (nano-modeline-compose
+     "RW"
+     buffer-name
+     (concat "(" mode-name
+	     (if branch (concat ", "
+				(propertize branch 'face 'italic)))
+	     ")" )
+     page-number)))
 
 ;; ---------------------------------------------------------------------
 

--- a/nano-modeline.el
+++ b/nano-modeline.el
@@ -259,17 +259,23 @@
 (defun nano-modeline-pdf-view-mode-p ()
   (derived-mode-p 'pdf-view-mode))
 
-(defun nano-modeline-pdf-pages ()
-  (concat " P" (number-to-string (eval '(pdf-view-current-page))) "/" (or (ignore-errors (number-to-string (eval '(pdf-cache-number-of-pages)))) "???")))
-
 (defun nano-modeline-pdf-view-mode ()
-  (let ((buffer-name (format-mode-line "%b"))
-        (mode-name   (format-mode-line "%m"))
-        (position    (nano-modeline-pdf-pages)))
-    (nano-modeline-compose (nano-modeline-status)
-                           buffer-name
-                           (concat "(" mode-name ")")
-                           position)))
+      (let ((buffer-name (format-mode-line "%b"))
+	    (mode-name   (format-mode-line "%m"))
+	    (branch      (vc-branch))
+	    (page-number (concat
+			  (number-to-string (pdf-view-current-page)) "/"
+			  (or (ignore-errors
+				(number-to-string (pdf-cache-number-of-pages)))
+			      "???"))))
+	(nano-modeline-compose
+	 "RW"
+	 buffer-name
+	 (concat "(" mode-name
+		 (if branch (concat ", "
+				    (propertize branch 'face 'italic)))
+		 ")" )
+	 page-number)))
 
 ;; ---------------------------------------------------------------------
 


### PR DESCRIPTION
This will remove the function and recover the page-numbers in let instead.
I keep the `nano-modeline-pdf-view-mode-p` as is.
The status will be "RW" and the rest of the function is exactly the same as default, to be able to recover the branch info if any.