### PR TITLE
nano-layout: hotfix default face

### DIFF
--- a/nano-layout.el
+++ b/nano-layout.el
@@ -18,8 +18,8 @@
 
 (setq default-frame-alist
       (append (list
-;;	       '(font . "Roboto Mono:style=Light:size=14")
-	       '(font . "Roboto Mono Emacs Regular:size=14")
+	       '(font . "Roboto Mono:style=Light:size=14")
+	       ;; '(font . "Roboto Mono Emacs Regular:size=14")
 	       '(min-height . 1)  '(height     . 45)
 	       '(min-width  . 40) '(width      . 81)
                '(vertical-scroll-bars . nil)


### PR DESCRIPTION
"Roboto Mono Emacs Regular" is a font that does not exist, as far as I can tell :wink: 