### PR TITLE
Split out basic color definitions from themes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+nano-custom.el

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-
-## GNU Emacs / N Λ N O 
+## GNU Emacs / N Λ N O
 
 **GNU Emacs / N Λ N O** is a set of configuration files for GNU Emacs
 such as to provide a nice and consistent look and feel as shown below.
@@ -39,63 +38,63 @@ $ emacs -q -l nano.el
 
 ### Installation
 
-If you like the result, you can merge the content of
-[nano.el](nano.el) into your emacs configuration file. To do so,
+If you like the result, you can merge the content of [nano.el](nano.el) into
+your emacs configuration file. To do so,
 you'll need to modify the `load-path` to include the nano emacs
 repository and then call for the different modules. The only mandatory
-module is the theme that defines 6 faces that are used in other
+module is `nano-faces` that defines 6 faces that are used in other
 modules.
 
 
 
 ### Modules
 
-
 <img align="right" alt="mandatory" src="https://img.shields.io/badge/-mandatory-red?style=flat-square">
 
-- **[nano-theme-light.el](./nano-theme-light.el)** or
-  **[nano-theme-dark.el](./nano-theme-dark.el)** Theses modules define a
-  light and dark themes respectively through the defnition of the different
-  faces that will be used by other modules.  It is thus mandatory (one of
-  dark or light version).
+- **[nano-faces.el](./nano-faces.el)** This module defines the fundamental faces
+  of nano theme. If your Emacs has a theme or color-scheme, make sure its loaded
+  before you load nano-faces so that its colors are used by nano.
 
 <img align="right" alt="optional" src="https://img.shields.io/badge/-optional-blue?style=flat-square">
 
-- **[nano.el](./nano.el)** This module is only used to test nano emacs
+- **[nano-theme-light.el](./nano-theme-light.el)** or
+  **[nano-theme-dark.el](./nano-theme-dark.el)** Theses modules define light and
+  dark themes respectively by overriding the base colors. If your Emacs is not
+  themed, you are encouraged to try one of these.
+
+<img align="right" alt="optional" src="https://img.shields.io/badge/-optional-blue?style=flat-square">
+
+- **[nano-theme.el](./nano-theme.el)** This module derives faces for several
+  popular emacs modes from the nano faces. You can either use them all by
+  calling `(nano-theme)`, or pick what you want by calling your selection of
+  `(nano-theme--` functions.
+
+<img align="right" alt="optional" src="https://img.shields.io/badge/-optional-blue?style=flat-square">
+
+- **[nano.el](./nano.el)** This module is mostly used to test nano emacs
   locally. Its content is supposed to be merged into an existing emacs
-  configuration.
+  configuration. See 'Quick test' section above.
 
 <img align="right" alt="optional" src="https://img.shields.io/badge/-optional-blue?style=flat-square">
 
 - **[nano-help.el](./nano-help.el)** This module provides a function to
   display a small message in the echo area.
 
-
 <img align="right" alt="optional" src="https://img.shields.io/badge/-optional-blue?style=flat-square">
 
-- **[nano-modeline.el](./nano-modeline.el)** This module define a
-  header line that is mode dependent and take care of hiding the
+- **[nano-modeline.el](./nano-modeline.el)** This module definse a
+  header line that is mode dependent and takes care of hiding the
   modeline when necessary.
-
 
 <img align="right" alt="optional" src="https://img.shields.io/badge/-optional-blue?style=flat-square">
 
 - **[nano-layout.el](./nano-layout.el)** This module define the overall layout of an emacs frame, defining default font, fringes, margins, etc.
-	
+
 <img align="right" alt="optional" src="https://img.shields.io/badge/-optional-blue?style=flat-square">
 
 - **[nano-splash.el](./nano-splash.el)** This module provides a splash
   screen when emacs is started.
 
-
 <img align="right" alt="optional" src="https://img.shields.io/badge/-optional-blue?style=flat-square">
 
 - **[nano-colors.el](./nano-colors.el)** This module provides a collection of colors palettes with function for easily accessing them.
-
-
-
-
-
-
-
-

--- a/nano-base-colors.el
+++ b/nano-base-colors.el
@@ -1,0 +1,100 @@
+;; ---------------------------------------------------------------------
+;; GNU Emacs / N Λ N O - Emacs made simple
+;; Copyright (C) 2020 - N Λ N O developers
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;; ---------------------------------------------------------------------
+;;
+;; Defines the 9 basic colors of the nano theme.
+;; The default values are loaded from well-known faces of Emacs.
+;;
+;; To change nano's appearance you therefore may:
+;; - Load any Emacs theme before loading nano to change the appearance
+;; - Load one of the few nano themes after this file. This will result inactive
+;;   the best experience.
+;; - Set your own colors by customizing nano group
+;;
+;; ---------------------------------------------------------------------
+
+(defgroup nano '()
+  "Faces and colors for the nano emacs theme")
+
+;; Derive our default color set from classic Emacs faces.
+;; This allows dropping nano components into already themed Emacsen with varying
+;; degrees of visual appeal.
+;;
+;; We memorize the default colorset in this var in order not to confuse
+;; customize: the STANDARD argument of defcustom gets re-evaluated by customize
+;; to determine if the current value is default or not.
+(defvar nano-base-colors--defaults
+  `((foreground . ,(face-foreground 'default nil t))
+    (background . ,(face-background 'default nil t))
+    (highlight . ,(face-background 'fringe nil t))
+    (critical . ,(face-foreground 'error nil t))
+    (salient . ,(face-foreground 'font-lock-keyword-face nil t))
+    (strong . ,(face-foreground 'default nil t))
+    (popout . ,(face-foreground 'font-lock-string-face nil t))
+    (subtle . ,(face-background 'mode-line-inactive nil t))
+    (faded . ,(face-foreground 'shadow nil t))))
+
+(defun nano-base-colors--get (name)
+  "Get default color associated with symbol NAME."
+  (cdr (assoc name nano-base-colors--defaults)))
+
+(defcustom nano-color-foreground (nano-base-colors--get 'foreground)
+  ""
+  :type 'color
+  :group 'nano)
+
+(defcustom nano-color-background (nano-base-colors--get 'background)
+  ""
+  :type 'color
+  :group 'nano)
+
+(defcustom nano-color-highlight (nano-base-colors--get 'highlight)
+  ""
+  :type 'color
+  :group 'nano)
+
+(defcustom nano-color-critical (nano-base-colors--get 'critical)
+  ""
+  :type 'color
+  :group 'nano)
+
+(defcustom nano-color-salient (nano-base-colors--get 'salient)
+  ""
+  :type 'color
+  :group 'nano)
+
+(defcustom nano-color-strong (nano-base-colors--get 'strong)
+  ""
+  :type 'color
+  :group 'nano)
+
+(defcustom nano-color-popout (nano-base-colors--get 'popout)
+  ""
+  :type 'color
+  :group 'nano)
+
+(defcustom nano-color-subtle (nano-base-colors--get 'subtle)
+  ""
+  :type 'color
+  :group 'nano)
+
+(defcustom nano-color-faded (nano-base-colors--get 'faded)
+  ""
+  :type 'color
+  :group 'nano)
+
+(provide 'nano-base-colors)

--- a/nano-faces.el
+++ b/nano-faces.el
@@ -29,6 +29,8 @@
 ;; ---------------------------------------------------------------------
 ;;; Code:
 
+(require 'nano-base-colors)
+
 ;; A theme is fully defined by these six faces
 
 (defface nano-face-default nil
@@ -143,149 +145,155 @@ background color that is barely perceptible."
   "Critical face for tags"
   :group 'nano)
 
-
-
-
+(defun nano-what-faces (pos)
+  "Get the font faces at POS."
+  (interactive "d")
+  (let ((faces (remq nil
+                     (list
+                      (get-char-property pos 'read-face-name)
+                      (get-char-property pos 'face)
+                      (plist-get (text-properties-at pos) 'face)))))
+    (message "Faces: %s" faces)))
 
 (defun nano-faces ()
   "Derive face attributes for nano-faces using nano-theme values."
   (set-face-attribute 'nano-face-default nil
-                       :foreground nano-color-foreground
-                       :background nano-color-background)
+                      :foreground nano-color-foreground
+                      :background nano-color-background)
   (set-face-attribute 'nano-face-critical nil
-                       :foreground nano-color-foreground
-                       :background nano-color-critical)
+                      :foreground nano-color-foreground
+                      :background nano-color-critical)
   (set-face-attribute 'nano-face-popout nil
-                       :foreground nano-color-popout)
+                      :foreground nano-color-popout)
 
   (if (display-graphic-p)
       (set-face-attribute 'nano-face-strong nil
-                           :foreground (face-foreground 'nano-face-default)
-                           :family "Roboto Mono"
-                           :weight 'medium)
+                          :foreground (face-foreground 'nano-face-default)
+                          :family "Roboto Mono"
+                          :weight 'medium)
     (set-face-attribute 'nano-face-strong nil
-                         :foreground (face-foreground 'nano-face-default)
-                         :weight 'bold))
+                        :foreground (face-foreground 'nano-face-default)
+                        :weight 'bold))
 
   (set-face-attribute 'nano-face-salient nil
-                       :foreground nano-color-salient
-                       :weight 'light)
+                      :foreground nano-color-salient
+                      :weight 'light)
 
   (set-face-attribute 'nano-face-faded nil
-                       :foreground nano-color-faded
-                       :weight 'light)
+                      :foreground nano-color-faded
+                      :weight 'light)
 
   (set-face-attribute 'nano-face-subtle nil
                       :background nano-color-subtle)
 
   (set-face-attribute 'nano-face-header-default nil
-          :foreground nano-color-foreground
-          :background nano-color-subtle
-          :box `(:line-width 1
-                 :color ,nano-color-background
-                 :style nil))
+                      :foreground nano-color-foreground
+                      :background nano-color-subtle
+                      :box `(:line-width 1
+                                         :color ,nano-color-background
+                                         :style nil))
 
   (set-face-attribute 'nano-face-tag-default nil
-          :foreground nano-color-foreground
-          :background nano-color-background
-          :family "Roboto Mono" :weight 'regular
-          :height (if (display-graphic-p) 120 1)
-          :box `(:line-width 1
-                 :color ,nano-color-foreground
-                 :style nil))
-  
+                      :foreground nano-color-foreground
+                      :background nano-color-background
+                      :family "Roboto Mono" :weight 'regular
+                      :height (if (display-graphic-p) 120 1)
+                      :box `(:line-width 1
+                                         :color ,nano-color-foreground
+                                         :style nil))
+
   (set-face-attribute 'nano-face-header-strong nil
-          :foreground nano-color-strong
-          :background nano-color-subtle
-          :family "Roboto Mono"
-          :weight 'medium
-          :box `(:line-width 1
-                 :color ,nano-color-background
-                 :style nil))
+                      :foreground nano-color-strong
+                      :background nano-color-subtle
+                      :family "Roboto Mono"
+                      :weight 'medium
+                      :box `(:line-width 1
+                                         :color ,nano-color-background
+                                         :style nil))
 
   (set-face-attribute 'nano-face-tag-strong nil
-          :foreground nano-color-strong
-          :background nano-color-subtle
-          :family "Roboto Mono" :weight 'regular
-          :height (if (display-graphic-p) 120 1)
-          :box `(:line-width 1
-                 :color ,nano-color-strong
-                 :style nil))
-  
-  (set-face-attribute 'nano-face-header-salient nil
-          :foreground nano-color-background
-          :background nano-color-salient
-          :box `(:line-width 1
-                 :color ,nano-color-background
-                 :style nil))
+                      :foreground nano-color-strong
+                      :background nano-color-subtle
+                      :family "Roboto Mono" :weight 'regular
+                      :height (if (display-graphic-p) 120 1)
+                      :box `(:line-width 1
+                                         :color ,nano-color-strong
+                                         :style nil))
 
-    (set-face-attribute 'nano-face-tag-salient nil
-          :foreground nano-color-background
-          :background nano-color-salient
-          :family "Roboto Mono" :weight 'regular
-          :height (if (display-graphic-p) 120 1)
-          :box `(:line-width 1
-                 :color ,nano-color-salient
-                 :style nil))
+  (set-face-attribute 'nano-face-header-salient nil
+                      :foreground nano-color-background
+                      :background nano-color-salient
+                      :box `(:line-width 1
+                                         :color ,nano-color-background
+                                         :style nil))
+
+  (set-face-attribute 'nano-face-tag-salient nil
+                      :foreground nano-color-background
+                      :background nano-color-salient
+                      :family "Roboto Mono" :weight 'regular
+                      :height (if (display-graphic-p) 120 1)
+                      :box `(:line-width 1
+                                         :color ,nano-color-salient
+                                         :style nil))
 
   (set-face-attribute 'nano-face-header-popout nil
-          :foreground nano-color-background
-          :background nano-color-popout
-          :box `(:line-width 1
-                 :color ,nano-color-background
-                 :style nil))
+                      :foreground nano-color-background
+                      :background nano-color-popout
+                      :box `(:line-width 1
+                                         :color ,nano-color-background
+                                         :style nil))
 
   (set-face-attribute 'nano-face-tag-popout nil
-          :foreground nano-color-background
-          :background nano-color-popout
-          :family "Roboto Mono" :weight 'regular
-          :height (if (display-graphic-p) 120 1)
-          :box `(:line-width 1
-                 :color ,nano-color-popout
-                 :style nil))
-  
+                      :foreground nano-color-background
+                      :background nano-color-popout
+                      :family "Roboto Mono" :weight 'regular
+                      :height (if (display-graphic-p) 120 1)
+                      :box `(:line-width 1
+                                         :color ,nano-color-popout
+                                         :style nil))
+
   (set-face-attribute 'nano-face-header-faded nil
-          :foreground nano-color-background
-          :background nano-color-faded
-          :box `(:line-width 1
-                 :color ,nano-color-background
-                 :style nil))
+                      :foreground nano-color-background
+                      :background nano-color-faded
+                      :box `(:line-width 1
+                                         :color ,nano-color-background
+                                         :style nil))
 
   (set-face-attribute 'nano-face-tag-faded nil
-          :foreground nano-color-background
-          :background nano-color-faded
-          :family "Roboto Mono" :weight 'regular
-          :height (if (display-graphic-p) 120 1)
-          :box `(:line-width 1
-                 :color ,nano-color-faded
-                 :style nil))
-  
+                      :foreground nano-color-background
+                      :background nano-color-faded
+                      :family "Roboto Mono" :weight 'regular
+                      :height (if (display-graphic-p) 120 1)
+                      :box `(:line-width 1
+                                         :color ,nano-color-faded
+                                         :style nil))
+
   (set-face-attribute 'nano-face-header-subtle nil)
 
   (set-face-attribute 'nano-face-header-critical nil
-          :foreground nano-color-background
-          :background nano-color-critical
-          :box `(:line-width 1
-                 :color ,nano-color-background
-                 :style nil))
+                      :foreground nano-color-background
+                      :background nano-color-critical
+                      :box `(:line-width 1
+                                         :color ,nano-color-background
+                                         :style nil))
   (set-face-attribute 'nano-face-tag-critical nil
-          :foreground nano-color-background
-          :background nano-color-critical
-          :family "Roboto Mono" :weight 'regular
-          :height (if (display-graphic-p) 120 1)
-          :box `(:line-width 1
-                 :color ,nano-color-critical
-                 :style nil))
-  
+                      :foreground nano-color-background
+                      :background nano-color-critical
+                      :family "Roboto Mono" :weight 'regular
+                      :height (if (display-graphic-p) 120 1)
+                      :box `(:line-width 1
+                                         :color ,nano-color-critical
+                                         :style nil))
+
   (set-face-attribute 'nano-face-header-separator nil
-          :inherit 'nano-face-default
-          :height 0.1)
+                      :inherit 'nano-face-default
+                      :height 0.1)
   (set-face-attribute 'nano-face-header-filler nil
-          :inherit 'nano-face-header-default
-          :height 0.1)
+                      :inherit 'nano-face-header-default
+                      :height 0.1)
   (set-face-attribute 'nano-face-header-highlight nil
-          :inherit 'nano-face-header-faded
-          :box nil))
+                      :inherit 'nano-face-header-faded
+                      :box nil))
 
 (provide 'nano-faces)
 ;;; nano-faces.el ends here

--- a/nano-theme-dark.el
+++ b/nano-theme-dark.el
@@ -15,23 +15,19 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ;; ---------------------------------------------------------------------
-(setq frame-background-mode   'dark)
+(require 'nano-base-colors)
 
 ;; Colors from Nord theme at https://www.nordtheme.com
-(defvar nano-color-foreground "#ECEFF4") ;; Snow Storm 3  / nord  6
-(defvar nano-color-background "#2E3440") ;; Polar Night 0 / nord  0
-(defvar nano-color-highlight  "#3B4252") ;; Polar Night 1 / nord  1
-(defvar nano-color-critical   "#EBCB8B") ;; Aurora        / nord 11
-(defvar nano-color-salient    "#81A1C1") ;; Frost         / nord  9
-(defvar nano-color-strong     "#ECEFF4") ;; Snow Storm 3  / nord  6
-(defvar nano-color-popout     "#D08770") ;; Aurora        / nord 12
-(defvar nano-color-subtle     "#434C5E") ;; Polar Night 2 / nord  2
-(defvar nano-color-faded      "#616E87") ;;
+(setq frame-background-mode     'dark)
+(setq nano-color-foreground "#ECEFF4") ;; Snow Storm 3  / nord  6
+(setq nano-color-background "#2E3440") ;; Polar Night 0 / nord  0
+(setq nano-color-highlight  "#3B4252") ;; Polar Night 1 / nord  1
+(setq nano-color-critical   "#EBCB8B") ;; Aurora        / nord 11
+(setq nano-color-salient    "#81A1C1") ;; Frost         / nord  9
+(setq nano-color-strong     "#ECEFF4") ;; Snow Storm 3  / nord  6
+(setq nano-color-popout     "#D08770") ;; Aurora        / nord 12
+(setq nano-color-subtle     "#434C5E") ;; Polar Night 2 / nord  2
+(setq nano-color-faded      "#616E87") ;;
 
-(require 'nano-faces)
-(nano-faces)
-
-(require 'nano-theme)
-(nano-theme)
 
 (provide 'nano-theme-dark)

--- a/nano-theme-light.el
+++ b/nano-theme-light.el
@@ -15,23 +15,18 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ;; ---------------------------------------------------------------------
-(setq frame-background-mode   'light)
+(require 'nano-base-colors)
 
 ;; Colors from Material design at https://material.io/
-(defvar nano-color-foreground "#37474F") ;; Blue Grey / L800
-(defvar nano-color-background "#FFFFFF") ;; White
-(defvar nano-color-highlight  "#F9F9F9") ;; Very Light Grey
-(defvar nano-color-critical   "#FF6F00") ;; Amber / L900
-(defvar nano-color-salient    "#673AB7") ;; Deep Purple / L500
-(defvar nano-color-strong     "#000000") ;; Black
-(defvar nano-color-popout     "#FFAB91") ;; Deep Orange / L200
-(defvar nano-color-subtle     "#ECEFF1") ;; Blue Grey / L50
-(defvar nano-color-faded      "#B0BEC5") ;; Blue Grey / L200
-
-(require 'nano-faces)
-(nano-faces)
-
-(require 'nano-theme)
-(nano-theme)
+(setq frame-background-mode    'light)
+(setq nano-color-foreground "#37474F") ;; Blue Grey / L800
+(setq nano-color-background "#FFFFFF") ;; White
+(setq nano-color-highlight  "#FAFAFA") ;; Very Light Grey
+(setq nano-color-critical   "#FF6F00") ;; Amber / L900
+(setq nano-color-salient    "#673AB7") ;; Deep Purple / L500
+(setq nano-color-strong     "#000000") ;; Black
+(setq nano-color-popout     "#FFAB91") ;; Deep Orange / L200
+(setq nano-color-subtle     "#ECEFF1") ;; Blue Grey / L50
+(setq nano-color-faded      "#B0BEC5") ;; Blue Grey / L200
 
 (provide 'nano-theme-light)

--- a/nano-theme.el
+++ b/nano-theme.el
@@ -30,6 +30,8 @@
 ;; ---------------------------------------------------------------------
 ;;; Code:
 
+(require 'nano-faces)
+
 ;; When we set a face, we take care of removing any previous settings
 (defun set-face (face style)
   "Reset FACE and make it inherit STYLE."

--- a/nano-theme.el
+++ b/nano-theme.el
@@ -49,8 +49,8 @@
 
   ;; XXX the following seems to be a no-op, should it be removed?
   (set-face-attribute 'default nil
-                       :foreground (face-foreground 'default)
-                       :background (face-background 'default))
+                      :foreground (face-foreground 'default)
+                      :background (face-background 'default))
 
   (if (display-graphic-p)
       (set-face-attribute 'bold nil :weight 'regular)
@@ -68,14 +68,14 @@
   (set-face 'cursor                                  'nano-face-default)
 
   (set-face-attribute 'cursor nil
-                       :background (face-foreground 'nano-face-default))
+                      :background (face-foreground 'nano-face-default))
   (set-face-attribute 'window-divider nil
-                       :foreground (face-background 'nano-face-default))
+                      :foreground (face-background 'nano-face-default))
   (set-face-attribute 'window-divider-first-pixel nil
-                       :foreground nano-color-highlight)
+                      :foreground nano-color-highlight)
   ;;                  :foreground (face-background 'nano-face-subtle))
   (set-face-attribute 'window-divider-last-pixel nil
-                       :foreground nano-color-highlight)
+                      :foreground nano-color-highlight)
   ;;                  :foreground (face-background 'nano-face-subtle)))
 
   ;; Semantic
@@ -91,8 +91,8 @@
   (set-face 'link                                    'nano-face-salient)
   (set-face 'fringe                                    'nano-face-faded)
   (set-face-attribute 'fringe nil
-                       :foreground (face-background 'nano-face-subtle)
-                       :background (face-background 'default))
+                      :foreground (face-background 'nano-face-subtle)
+                      :background (face-background 'default))
   (set-face 'isearch                                  'nano-face-strong)
   (set-face 'isearch-fail                              'nano-face-faded)
   (set-face 'lazy-highlight                           'nano-face-subtle)
@@ -661,4 +661,6 @@ function is a convenience wrapper used by `describe-package-1'."
   (nano-theme--markdown)
   (nano-theme--ivy)
   (nano-theme--hl-line))
+
+
 (provide 'nano-theme)

--- a/nano.el
+++ b/nano.el
@@ -24,12 +24,35 @@
 ;; Window layout (optional)
 (require 'nano-layout)
 
-;; Theme (mandatory)
+;; Theming Command line options (this will cancel warning messages)
 (add-to-list 'command-switch-alist '("-dark"   . (lambda (args))))
 (add-to-list 'command-switch-alist '("-light"  . (lambda (args))))
-(if (member "-dark" command-line-args)
-    (require 'nano-theme-dark)
-  (require 'nano-theme-light))
+(add-to-list 'command-switch-alist '("-default"  . (lambda (args))))
+
+(cond
+ ((member "-default" command-line-args) t)
+ ((member "-dark" command-line-args) (require 'nano-theme-dark))
+ (t (require 'nano-theme-light)))
+
+;; Customize support for 'emacs -q' (Optional)
+;; You can enable customizations by creating the nano-custom.el file
+;; with e.g. `touch nano-custom.el` in the folder containing this file.
+(let* ((this-file  (or load-file-name (buffer-file-name)))
+       (this-dir  (file-name-directory this-file))
+       (custom-path  (concat this-dir "nano-custom.el")))
+  (when (and (eq nil user-init-file)
+             (eq nil custom-file)
+             (file-exists-p custom-path))
+    (setq user-init-file this-file)
+    (setq custom-file custom-path)
+    (load custom-file)))
+
+;; Theme
+(require 'nano-faces)
+(nano-faces)
+
+(require 'nano-theme)
+(nano-theme)
 
 ;; Nano default settings (optional)
 (require 'nano-defaults)


### PR DESCRIPTION
- nano-base-colors: customizable base colors
- nano.el: support for -default arg, to use default Emacs colors
- nano.el: opt-in support for customize even when running with -q

#### What this is

This is in line of my previous PR aiming at making nano-emacs easier to integrate into existing configurations.
This separates color definitions from themes, and adds a small new set of default colors that are derived from a few basic Emacs theme. This allows smooth, zero-config, integration into existing themes - to some extent.

With this change, I can finally load nano-emacs modeline with minimal code in my existing config. It looks like this:
~~~~elisp
(add-to-list 'load-path "/home/zor/taf/my-nano-emacs")

(require 'nano-faces)
(nano-faces)

(require 'nano-theme)
(nano-theme--mode-line)

(require 'nano-modeline)
~~~~
Not perfect, but good enough.

#### Customize !

I also added some machinery to `nano.el` to make customize work again if and only if a `nano-custom.el` file is created by the user next to it **and** emacs was started with `-q`. In effect, this allows a user to checkout this directory, `alias nane=\emacs -q -l <path-to-nano-emacs>/nano.el -dark` and have a working setup coexisting with another Emacs (which is my use-case).

I believe there are a few more aspects to consider when talking about standalone nano-emacs installed outside .emacs.d - I'd be delighted to share some ideas in a dedicated issue if you are interested to go down this route.

As things stand, changing colors require an Emacs restart (!) to see any impact, mostly because faces are derived proceduraly.  I'm interested in fixing that next, but I haven't yet figured out if it will be with some form of hooks, or with more substantial refactoring of the `(nano-faces)` function.