### PR TITLE
fix header-line

### DIFF
--- a/nano-modeline.el
+++ b/nano-modeline.el
@@ -65,7 +65,7 @@
 
 (defun nano-modeline-compose (status name primary secondary &optional actions)
   "Compose a string with provided information"
-  (let* ((char-width    (window-font-width nil 'default))
+  (let* ((char-width    (window-font-width nil 'header-line))
 	 (actions       (or actions '( ("<" . previous-buffer)
 				       (">" . next-buffer))))
 	 (actions-length (apply '+ (mapcar 'length (mapcar 'car actions))))
@@ -89,9 +89,10 @@
 			         'display `(raise ,space-down))
 		(propertize primary 'face 'nano-face-header-default)))
          (right (concat secondary " "))
-         (available-width (- (window-body-width) 1
+         (available-width (- (window-total-width) 1
 			     (* 2 (length actions)) actions-length
-			     (length prefix) (length left) (length right)))
+			     (length prefix) (length left) (length right)
+			     (/ (window-right-divider-width) char-width)))
 	 (available-width (max 1 available-width)))
     (concat prefix
 	    (if gui


### PR DESCRIPTION
Fixed bugs:
The length of header-line will change along with:
1.  the body font size changes
<img width="707" alt="image" src="https://user-images.githubusercontent.com/19836675/101141963-5241d480-3658-11eb-9eef-ba33256aaf63.png">

2. the window-body-size changes
<img width="699" alt="image" src="https://user-images.githubusercontent.com/19836675/101141093-25d98880-3657-11eb-9663-45f9451c6b2a.png">

How did fix it:
1. the font size in header-line is always fixed when the font size in body changed, but the computation of the  length of header-line uses the body font size: `(window-font-width nil 'default)`
I changed it to `header-line`: `(window-font-width nil 'header-line)`

2. there are some modes change the window margin and width to center text, but 
the computation of the length of header-line rely on the `window-body-size`, which sometimes changes in some modes, so replaced the `window-body-size` to `window-total-size`, and subtract the right divider width `(/ (window-right-divider-width) char-width)`
