### PR TITLE
*-theme: make themes switchable on the go

### DIFF
--- a/nano-theme-dark.el
+++ b/nano-theme-dark.el
@@ -17,17 +17,21 @@
 ;; ---------------------------------------------------------------------
 (require 'nano-base-colors)
 
-;; Colors from Nord theme at https://www.nordtheme.com
-(setq frame-background-mode     'dark)
-(setq nano-color-foreground "#ECEFF4") ;; Snow Storm 3  / nord  6
-(setq nano-color-background "#2E3440") ;; Polar Night 0 / nord  0
-(setq nano-color-highlight  "#3B4252") ;; Polar Night 1 / nord  1
-(setq nano-color-critical   "#EBCB8B") ;; Aurora        / nord 11
-(setq nano-color-salient    "#81A1C1") ;; Frost         / nord  9
-(setq nano-color-strong     "#ECEFF4") ;; Snow Storm 3  / nord  6
-(setq nano-color-popout     "#D08770") ;; Aurora        / nord 12
-(setq nano-color-subtle     "#434C5E") ;; Polar Night 2 / nord  2
-(setq nano-color-faded      "#616E87") ;;
+(defun nano-theme-set-dark ()
+  "Apply dark Nano theme base."
+  ;; Colors from Nord theme at https://www.nordtheme.com
+  (setq frame-background-mode     'dark)
+  (setq nano-color-foreground "#ECEFF4") ;; Snow Storm 3  / nord  6
+  (setq nano-color-background "#2E3440") ;; Polar Night 0 / nord  0
+  (setq nano-color-highlight  "#3B4252") ;; Polar Night 1 / nord  1
+  (setq nano-color-critical   "#EBCB8B") ;; Aurora        / nord 11
+  (setq nano-color-salient    "#81A1C1") ;; Frost         / nord  9
+  (setq nano-color-strong     "#ECEFF4") ;; Snow Storm 3  / nord  6
+  (setq nano-color-popout     "#D08770") ;; Aurora        / nord 12
+  (setq nano-color-subtle     "#434C5E") ;; Polar Night 2 / nord  2
+  (setq nano-color-faded      "#677691") ;;
+  )
 
+(nano-theme-set-dark)
 
 (provide 'nano-theme-dark)

--- a/nano-theme-light.el
+++ b/nano-theme-light.el
@@ -16,17 +16,20 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ;; ---------------------------------------------------------------------
 (require 'nano-base-colors)
-
-;; Colors from Material design at https://material.io/
-(setq frame-background-mode    'light)
-(setq nano-color-foreground "#37474F") ;; Blue Grey / L800
-(setq nano-color-background "#FFFFFF") ;; White
-(setq nano-color-highlight  "#FAFAFA") ;; Very Light Grey
-(setq nano-color-critical   "#FF6F00") ;; Amber / L900
-(setq nano-color-salient    "#673AB7") ;; Deep Purple / L500
-(setq nano-color-strong     "#000000") ;; Black
-(setq nano-color-popout     "#FFAB91") ;; Deep Orange / L200
-(setq nano-color-subtle     "#ECEFF1") ;; Blue Grey / L50
-(setq nano-color-faded      "#B0BEC5") ;; Blue Grey / L200
+(defun nano-theme-set-light ()
+  "Apply light Nano theme base."
+  ;; Colors from Material design at https://material.io/
+  (setq frame-background-mode    'light)
+  (setq nano-color-foreground "#37474F") ;; Blue Grey / L800
+  (setq nano-color-background "#FFFFFF") ;; White
+  (setq nano-color-highlight  "#FAFAFA") ;; Very Light Grey
+  (setq nano-color-critical   "#FF6F00") ;; Amber / L900
+  (setq nano-color-salient    "#673AB7") ;; Deep Purple / L500
+  (setq nano-color-strong     "#000000") ;; Black
+  (setq nano-color-popout     "#FFAB91") ;; Deep Orange / L200
+  (setq nano-color-subtle     "#ECEFF1") ;; Blue Grey / L50
+  (setq nano-color-faded      "#B0BEC5") ;; Blue Grey / L200
+  )
+(nano-theme-set-light)
 
 (provide 'nano-theme-light)


### PR DESCRIPTION
This creates two new commands: nano-theme-set-dark and
nano-theme-set-light.
Use
```
  (nano-theme-set-dark)
  (nano-faces)
  (nano-theme)
```
to switch variables internally and apply the new theme on the go.
It preserves the old behaviour of enabling a theme via `(require nano-theme-dark)`, too.
My elisp is not very good (couldn't make it work with `deftheme`'s custom commands), but it's a start for #26 :)