### PR TITLE
use title/author keywords

### DIFF
--- a/nano-writer.el
+++ b/nano-writer.el
@@ -84,6 +84,14 @@ etc.
                            :family "Roboto" :height 160)
   (face-remap-add-relative 'org-level-3
                            :family "Roboto" :height 150)
+  (face-remap-add-relative 'org-document-info
+                           :family "Roboto Slab")
+  (face-remap-add-relative 'org-document-title
+                           :family "Roboto Slab" 
+                           :height 200 
+                           :weight 'bold)
+  ;; hide title / author ... keywords
+  (setq-local org-hidden-keywords '(title author date startup))
 
   ;; Header line
   (setq header-line-format nil)

--- a/nano-writer.el
+++ b/nano-writer.el
@@ -116,14 +116,4 @@ etc.
   (org-num-mode)
   (setq org-num-format-function 'writer-mode--num-format)
 
-  ;; Markup
-  (make-variable-buffer-local 'org-emphasis-alist)
-  (setq org-emphasis-alist '(("*" bold)
-                             ("/" italic)
-                             ("_" underline)
-                             ("=" org-verbatim verbatim)
-                             ("~" org-code verbatim)
-                             ("+" (:family "Roboto Slab"
-                                   :weight 'bold :height 200)))))
-
 (provide 'nano-writer)

--- a/nano-writer.org
+++ b/nano-writer.org
@@ -1,7 +1,6 @@
-
-
-+NΛNO Writer Mode+
-/Nicolas P. Rougier — December 2020/
+#+title:NΛNO Writer mode
+#+author:Nicolas P. Rougier
+#+date:December 2020
 
 *Abstract |* NΛNO writer mode is an emacs minor mode based on org-mode
            whose goal is to offer a nice writing environment such that


### PR DESCRIPTION
Change the default faces for title and document info (date, author) so that it looks the same as in your demo.
The keywords are hidden by setting `org-hidden-keywords`.

Using these keywords has the advantage of being parseable by pandoc or org-export and related tools.