### PR TITLE
modeline: Add vterm support

### DIFF
--- a/nano-modeline.el
+++ b/nano-modeline.el
@@ -221,6 +221,9 @@
 (defun nano-modeline-term-mode-p ()
   (derived-mode-p 'term-mode))
 
+(defun nano-modeline-vterm-mode-p ()
+  (derived-mode-p 'vterm-mode))
+
 (defun nano-modeline-term-mode ()
   (nano-modeline-compose " >_ "
                          "Terminal"
@@ -451,6 +454,7 @@
            ((nano-modeline-org-agenda-mode-p)      (nano-modeline-org-agenda-mode))
            ((nano-modeline-org-clock-mode-p)       (nano-modeline-org-clock-mode))
            ((nano-modeline-term-mode-p)            (nano-modeline-term-mode))
+           ((nano-modeline-vterm-mode-p)           (nano-modeline-term-mode))
            ((nano-modeline-mu4e-dashboard-mode-p)  (nano-modeline-mu4e-dashboard-mode))
            ((nano-modeline-mu4e-main-mode-p)       (nano-modeline-mu4e-main-mode))
            ((nano-modeline-mu4e-headers-mode-p)    (nano-modeline-mu4e-headers-mode))


### PR DESCRIPTION
Hello @rougier 👋 Thank you very much for all your efforts and sharing of this wonderful collection of configuration.  

I figured it'd be nice to have [vterm](https://github.com/akermu/emacs-libvterm) support in the modeline.  
As you can see, I've just leaned on the existing `nano-modeline-term-mode` function so it acts exactly the same:
<img width="589" alt="image" src="https://user-images.githubusercontent.com/3392199/104361853-eed67c80-550a-11eb-81cb-987784ec527c.png">
