### PR TITLE
Add detections for Emacs built without X11.

### DIFF
--- a/nano-defaults.el
+++ b/nano-defaults.el
@@ -26,7 +26,7 @@
 ;; No message in scratch buffer
 (setq initial-scratch-message nil)
 
-;; Initial buffer 
+;; Initial buffer
 (setq initial-buffer-choice nil)
 
 ;; No frame title
@@ -46,7 +46,7 @@
 
 ;; User mail address
 (setq user-mail-address "Nicolas.Rougier@inria.fr")
-      
+
 ;; No empty line indicators
 (setq indicate-empty-lines nil)
 
@@ -88,10 +88,10 @@
   (global-set-key (kbd "<mouse-5>") 'scroll-up-line))
 
 ;; No scroll bars
-(scroll-bar-mode 0)
+(if (fboundp 'scroll-bar-mode) (scroll-bar-mode nil))
 
 ;; No toolbar
-(tool-bar-mode 0)
+(if (fboundp 'tool-bar-mode) (tool-bar-mode nil))
 
 ;; No menu bar
 (if (display-graphic-p)

--- a/nano-layout.el
+++ b/nano-layout.el
@@ -56,7 +56,7 @@
       inhibit-startup-message t
       inhibit-startup-echo-area-message t
       initial-scratch-message nil)
-(tool-bar-mode 0)
+(if (fboundp 'tool-bar-mode) (tool-bar-mode nil))
 (tooltip-mode 0)
 (menu-bar-mode 0)
 ;; (global-hl-line-mode 1)


### PR DESCRIPTION
On Termux this can directly lead to an error and on Nix's nox lead to a warning.
It's happy to see the welcome screen again.
Test with `nix-shell -p emacs-nox which --pure` or on smartphones.
Close #70 , but should we add conditions on `quick-help.org` to choose what to display or not?