### PR TITLE
Require disp-table before attempting to acces standard-display-table

### DIFF
--- a/nano-layout.el
+++ b/nano-layout.el
@@ -16,6 +16,8 @@
 ;; along with this program. If not, see <http://www.gnu.org/licenses/>.
 ;; ---------------------------------------------------------------------
 
+(require 'disp-table)
+
 (setq default-frame-alist
       (append (list
 	       '(font . "Roboto Mono:style=Light:size=14")


### PR DESCRIPTION
This PR fixes #28. It was suggested in email following my Emacs bug report.

This PR replaces #67 which for reasons unknown wasn't merging cleanly.
