### PR TITLE
Correct typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ modules.
   
   ![](./images/nano-mu4e.png)
 
-- **[nano-minibuffer.el](./nano-minibufrer.el)**
+- **[nano-minibuffer.el](./nano-minibuffer.el)**
 
   > Minibuffer using [mini-frame](https://github.com/muffinmad/emacs-mini-frame)
   


### PR DESCRIPTION
The `nano-minibuffer.el` link goes to `nano-minibufrer.el`, which 404s. This corrects the link.