### PR TITLE
Added options to use custom font, variable pitch font, and custom font easily customizable font size.

### DIFF
--- a/nano-faces.el
+++ b/nano-faces.el
@@ -194,12 +194,12 @@ background color that is barely perceptible."
   (set-face-attribute 'nano-face-popout nil
                       :foreground nano-color-popout)
 
-  (if (display-graphic-p)
-      (set-face-attribute 'nano-face-variable-pitch nil
+  (set-face-attribute 'nano-face-variable-pitch nil
                           :foreground (face-foreground 'nano-face-default)
                           :background (face-background 'nano-face-default)
                           :family nano-family-variable-pitch
                           :height (* nano-font-size 10))
+  (if (display-graphic-p)
       (set-face-attribute 'nano-face-strong nil
                           :foreground (face-foreground 'nano-face-default)
                           :weight 'medium)

--- a/nano-faces.el
+++ b/nano-faces.el
@@ -33,14 +33,14 @@
 
 
 
-(defcustom nano-family "Roboto Mono"
+(defcustom nano-font-family-monospaced "Roboto Mono"
   "Name of the font-family to use for nano.
 Defaults to Roboto Mono. Customizing this might lead to conflicts
 if the family does not have sufficient bold/light etc faces."
   :group 'nano
   :type 'string)
 
-(defcustom nano-family-variable-pitch nil
+(defcustom nano-font-family-proportional nil
   "Font to use for variable pitch faces.
 Setting this allows nano to display variable pitch faces when,
 for instance, 'variable-pitch-mode' or 'mixed-pitch-mode' is active in a buffer.
@@ -49,7 +49,9 @@ Defaults to nil."
   :type 'string)
 
 (defcustom nano-font-size 14
-  "Default value for the font size of nano-theme in pt units."
+  "Default value for the font size of nano-theme in pt units.
+Note: to change this after startup, call
+\(nano-faces\) and \(nano-themes\)."
   :group 'nano
   :type 'integer)
 
@@ -186,7 +188,7 @@ background color that is barely perceptible."
   (set-face-attribute 'nano-face-default nil
                       :foreground nano-color-foreground
                       :background nano-color-background
-                      :family     nano-family
+                      :family     nano-font-family-monospaced
                       :height       (* nano-font-size 10))
   (set-face-attribute 'nano-face-critical nil
                       :foreground nano-color-foreground
@@ -197,7 +199,7 @@ background color that is barely perceptible."
   (set-face-attribute 'nano-face-variable-pitch nil
                           :foreground (face-foreground 'nano-face-default)
                           :background (face-background 'nano-face-default)
-                          :family nano-family-variable-pitch
+                          :family nano-font-family-proportional
                           :height (* nano-font-size 10))
   (if (display-graphic-p)
       (set-face-attribute 'nano-face-strong nil
@@ -229,7 +231,10 @@ background color that is barely perceptible."
                       :foreground nano-color-foreground
                       :background nano-color-background
                       :weight 'regular
-                      :height (if (display-graphic-p) 120 1)
+                      :height (if (display-graphic-p)
+                                  (round
+                                   (* 0.85 (* 10 nano-font-size)))
+                                                1)
                       :box `(:line-width 1
                                          :color ,nano-color-foreground
                                          :style nil))
@@ -246,7 +251,10 @@ background color that is barely perceptible."
                       :foreground nano-color-strong
                       :background nano-color-subtle
                       :weight 'regular
-                      :height (if (display-graphic-p) 120 1)
+                      :height (if (display-graphic-p)
+                                  (round
+                                   (* 0.85 (* 10 nano-font-size)))
+                                                1)
                       :box `(:line-width 1
                                          :color ,nano-color-strong
                                          :style nil))
@@ -262,7 +270,10 @@ background color that is barely perceptible."
                       :foreground nano-color-background
                       :background nano-color-salient
                       :weight 'regular
-                      :height (if (display-graphic-p) 120 1)
+                      :height (if (display-graphic-p)
+                                  (round
+                                   (* 0.85 (* 10 nano-font-size)))
+                                                1)
                       :box `(:line-width 1
                                          :color ,nano-color-salient
                                          :style nil))
@@ -278,7 +289,10 @@ background color that is barely perceptible."
                       :foreground nano-color-background
                       :background nano-color-popout
                       :weight 'regular
-                      :height (if (display-graphic-p) 120 1)
+                      :height (if (display-graphic-p)
+                                  (round
+                                   (* 0.85 (* 10 nano-font-size)))
+                                                1)
                       :box `(:line-width 1
                                          :color ,nano-color-popout
                                          :style nil))
@@ -294,7 +308,10 @@ background color that is barely perceptible."
                       :foreground nano-color-background
                       :background nano-color-faded
                       :weight 'regular
-                      :height (if (display-graphic-p) 120 1)
+                      :height (if (display-graphic-p)
+                                  (round
+                                   (* 0.85 (* 10 nano-font-size)))
+                                                1)
                       :box `(:line-width 1
                                          :color ,nano-color-faded
                                          :style nil))
@@ -311,7 +328,10 @@ background color that is barely perceptible."
                       :foreground nano-color-background
                       :background nano-color-critical
                       :weight 'regular
-                      :height (if (display-graphic-p) 120 1)
+                      :height (if (display-graphic-p)
+                                  (round
+                                   (* 0.85 (* 10 nano-font-size)))
+                                                1)
                       :box `(:line-width 1
                                          :color ,nano-color-critical
                                          :style nil))

--- a/nano-faces.el
+++ b/nano-faces.el
@@ -31,10 +31,36 @@
 
 (require 'nano-base-colors)
 
-;; A theme is fully defined by these six faces
+
+
+(defcustom nano-family "Roboto Mono"
+  "Name of the font-family to use for nano.
+Defaults to Roboto Mono. Customizing this might lead to conflicts
+if the family does not have sufficient bold/light etc faces."
+  :group 'nano
+  :type 'string)
+
+(defcustom nano-family-variable-pitch nil
+  "Font to use for variable pitch faces.
+Setting this allows nano to display variable pitch faces when,
+for instance, 'variable-pitch-mode' or 'mixed-pitch-mode' is active in a buffer.
+Defaults to nil."
+  :group 'nano
+  :type 'string)
+
+(defcustom nano-font-size 14
+  "Default value for the font size of nano-theme in pt units."
+  :group 'nano
+  :type 'integer)
+
+;; A theme is fully defined by these seven faces
 
 (defface nano-face-default nil
   "Default face is used for regular information."
+  :group 'nano)
+
+(defface nano-face-variable-pitch nil
+  "Default variable-pitch face is used for variable pitch mode."
   :group 'nano)
 
 (defface nano-face-critical nil
@@ -159,7 +185,9 @@ background color that is barely perceptible."
   "Derive face attributes for nano-faces using nano-theme values."
   (set-face-attribute 'nano-face-default nil
                       :foreground nano-color-foreground
-                      :background nano-color-background)
+                      :background nano-color-background
+                      :family     nano-family
+                      :height       (* nano-font-size 10))
   (set-face-attribute 'nano-face-critical nil
                       :foreground nano-color-foreground
                       :background nano-color-critical)
@@ -167,9 +195,13 @@ background color that is barely perceptible."
                       :foreground nano-color-popout)
 
   (if (display-graphic-p)
+      (set-face-attribute 'nano-face-variable-pitch nil
+                          :foreground (face-foreground 'nano-face-default)
+                          :background (face-background 'nano-face-default)
+                          :family nano-family-variable-pitch
+                          :height (* nano-font-size 10))
       (set-face-attribute 'nano-face-strong nil
                           :foreground (face-foreground 'nano-face-default)
-                          :family "Roboto Mono"
                           :weight 'medium)
     (set-face-attribute 'nano-face-strong nil
                         :foreground (face-foreground 'nano-face-default)
@@ -196,7 +228,7 @@ background color that is barely perceptible."
   (set-face-attribute 'nano-face-tag-default nil
                       :foreground nano-color-foreground
                       :background nano-color-background
-                      :family "Roboto Mono" :weight 'regular
+                      :weight 'regular
                       :height (if (display-graphic-p) 120 1)
                       :box `(:line-width 1
                                          :color ,nano-color-foreground
@@ -213,7 +245,7 @@ background color that is barely perceptible."
   (set-face-attribute 'nano-face-tag-strong nil
                       :foreground nano-color-strong
                       :background nano-color-subtle
-                      :family "Roboto Mono" :weight 'regular
+                      :weight 'regular
                       :height (if (display-graphic-p) 120 1)
                       :box `(:line-width 1
                                          :color ,nano-color-strong
@@ -229,7 +261,7 @@ background color that is barely perceptible."
   (set-face-attribute 'nano-face-tag-salient nil
                       :foreground nano-color-background
                       :background nano-color-salient
-                      :family "Roboto Mono" :weight 'regular
+                      :weight 'regular
                       :height (if (display-graphic-p) 120 1)
                       :box `(:line-width 1
                                          :color ,nano-color-salient
@@ -245,7 +277,7 @@ background color that is barely perceptible."
   (set-face-attribute 'nano-face-tag-popout nil
                       :foreground nano-color-background
                       :background nano-color-popout
-                      :family "Roboto Mono" :weight 'regular
+                      :weight 'regular
                       :height (if (display-graphic-p) 120 1)
                       :box `(:line-width 1
                                          :color ,nano-color-popout
@@ -261,7 +293,7 @@ background color that is barely perceptible."
   (set-face-attribute 'nano-face-tag-faded nil
                       :foreground nano-color-background
                       :background nano-color-faded
-                      :family "Roboto Mono" :weight 'regular
+                      :weight 'regular
                       :height (if (display-graphic-p) 120 1)
                       :box `(:line-width 1
                                          :color ,nano-color-faded
@@ -278,7 +310,7 @@ background color that is barely perceptible."
   (set-face-attribute 'nano-face-tag-critical nil
                       :foreground nano-color-background
                       :background nano-color-critical
-                      :family "Roboto Mono" :weight 'regular
+                      :weight 'regular
                       :height (if (display-graphic-p) 120 1)
                       :box `(:line-width 1
                                          :color ,nano-color-critical

--- a/nano-layout.el
+++ b/nano-layout.el
@@ -20,7 +20,8 @@
 
 (setq default-frame-alist
       (append (list
-	       '(font . "Roboto Mono:style=Light:size=14")
+               ;; Font size and family is set by nano-face-default
+	       ;;'(font . "Roboto Mono:style=Light:size=14")
 	       ;; '(font . "Roboto Mono Emacs Regular:size=14")
 	       '(min-height . 1)  '(height     . 45)
 	       '(min-width  . 1) '(width      . 81)

--- a/nano-theme.el
+++ b/nano-theme.el
@@ -69,7 +69,7 @@
   ;;(set-face 'fixed-pitch                                     'default)
   (set-face 'fixed-pitch-serif                       'nano-face-default)
   (set-face 'cursor                                  'nano-face-default)
-  (if 'nano-face-family-variable-pitch
+  (if 'nano-font-family-proportional
       (set-face-attribute 'variable-pitch nil ;; to work with mixed-pitch
                 :foreground (face-foreground 'default)
                 :background (face-background 'default)

--- a/nano-theme.el
+++ b/nano-theme.el
@@ -59,6 +59,7 @@
     (set-face-attribute 'bold nil :weight 'bold))
 
   ;; Structural
+  (set-face 'default                                 'nano-face-default)
   (set-face 'bold                                     'nano-face-strong)
   (set-face 'italic                                    'nano-face-faded)
   (set-face 'bold-italic                              'nano-face-strong)
@@ -66,7 +67,9 @@
   (set-face 'highlight                                'nano-face-subtle)
   ;;(set-face 'fixed-pitch                                     'default)
   (set-face 'fixed-pitch-serif                       'nano-face-default)
-  (set-face 'variable-pitch                          'nano-face-default)
+  (if 'nano-face-family-variable-pitch
+      (set-face 'variable-pitch       'nano-face-variable-pitch)
+      (set-face 'variable-pitch                     'nano-face-default))
   (set-face 'cursor                                  'nano-face-default)
 
   (set-face-attribute 'cursor nil

--- a/nano-theme.el
+++ b/nano-theme.el
@@ -52,14 +52,15 @@
   ;; XXX the following seems to be a no-op, should it be removed?
   (set-face-attribute 'default nil
                       :foreground (face-foreground 'default)
-                      :background (face-background 'default))
+                      :background (face-background 'default)
+                      :family     (face-attribute 'nano-face-default :family)
+                      :height     (face-attribute 'nano-face-default :height))
 
   (if (display-graphic-p)
       (set-face-attribute 'bold nil :weight 'regular)
     (set-face-attribute 'bold nil :weight 'bold))
 
   ;; Structural
-  (set-face 'default                                 'nano-face-default)
   (set-face 'bold                                     'nano-face-strong)
   (set-face 'italic                                    'nano-face-faded)
   (set-face 'bold-italic                              'nano-face-strong)

--- a/nano-theme.el
+++ b/nano-theme.el
@@ -68,10 +68,14 @@
   (set-face 'highlight                                'nano-face-subtle)
   ;;(set-face 'fixed-pitch                                     'default)
   (set-face 'fixed-pitch-serif                       'nano-face-default)
-  (if 'nano-face-family-variable-pitch
-      (set-face 'variable-pitch       'nano-face-variable-pitch)
-      (set-face 'variable-pitch                     'nano-face-default))
   (set-face 'cursor                                  'nano-face-default)
+  (if 'nano-face-family-variable-pitch
+      (set-face-attribute 'variable-pitch nil ;; to work with mixed-pitch
+                :foreground (face-foreground 'default)
+                :background (face-background 'default)
+                :family     (face-attribute 'nano-face-variable-pitch :family)
+                :height     (face-attribute 'nano-face-variable-pitch :height))
+      (set-face 'variable-pitch                     'nano-face-default))
 
   (set-face-attribute 'cursor nil
                       :background (face-foreground 'nano-face-default))


### PR DESCRIPTION
Hi! I've been using nano on and off, as while I really like the design philosophy, I really like using variable-pitch fonts while writing, which are unfortunately a little hard to use with  nano as it does not play well with `variable-pitch-mode` or `mixed-pitch-mode`.
This PR is to "fix" that.

It does a couple of things, not all of which you may be a fan of as you mentioned in #18 , but I think at least some elements might be worthwile:
- Removes the hard-coded font definition from `nano-layout`
- Removes the hard-coded font definition from the nano-faces, instead delagating this to `nano-default-face`
- Adds a customization option for the font size, defaults to 14.
- Adds a customization option for the default font family. This still defaults to Roboto Mono, but is now customizable, with a warning that other fonts may not work.
- Adds `nano-face-variable-pitch` and the accompanying variable `nano-family-variable-pitch`, which, if set, sets `variable-pitch` to this face, allowing `variable-pitch-mode` to work properly.

All faces visible in this image. It works very well, have not yet encountered any problems.
![image](https://user-images.githubusercontent.com/21983833/119844438-f44fc480-bef7-11eb-8aac-5746a95e8765.png)

Let me know what you think! I'm very happy that I can use nano with variable pitch now, I hope this might be useful to others who would like to as well. :) Thank you again for `nano-emacs`, it's really a delight.
