### PR TITLE
Basic solaire mode functionality

### DIFF
--- a/nano-theme.el
+++ b/nano-theme.el
@@ -730,6 +730,16 @@ function is a convenience wrapper used by `describe-package-1'."
     (set-face 'company-tooltip-annotation                                    'nano-face-default)
     (set-face 'company-tooltip-annotation-selection        '(nano-face-strong nano-face-subtle))))
 
+(defun nano-theme--solaire ()
+  "Define faces compatible with 'solaire-mode'."
+  (with-eval-after-load 'solaire-mode
+    (set-face-attribute 'solaire-default-face nil
+        :background (color-darken-name nano-color-background 3 ))
+    (set-face-attribute 'solaire-hl-line-face nil
+        :background (color-darken-name nano-color-highlight 3))
+    (set-face-attribute 'solaire-line-number-face nil
+        :background (color-darken-name nano-color-background 3 ))))
+
 (defun nano-theme ()
   "Derive many, many faces from the core nano faces."
   (nano-theme--basics)
@@ -763,6 +773,7 @@ function is a convenience wrapper used by `describe-package-1'."
   (nano-theme--helm-ff)
   (nano-theme--helm-grep)
   (nano-theme--hl-line)
-  (nano-theme--company))
+  (nano-theme--company)
+  (nano-theme--solaire))
 
 (provide 'nano-theme)


### PR DESCRIPTION
This PR adds the minimum to work with [solaire-mode](https://github.com/hlissner/emacs-solaire-mode), which darkens non-file-visiting buffers. The values are picked somewhat arbitrarily, but they look nice I think. Should not conflict with non-solaire-mode users.

Dark
![image](https://user-images.githubusercontent.com/21983833/119869303-97600880-bf0f-11eb-99eb-658e13237964.png)

Light
![image](https://user-images.githubusercontent.com/21983833/119869456-c9716a80-bf0f-11eb-9c3a-c55ec98a26cc.png)
