### PR TITLE
On the fly theme switcing and refreshing

### DIFF
--- a/nano-theme-dark.el
+++ b/nano-theme-dark.el
@@ -30,6 +30,8 @@
   (setq nano-color-popout     "#D08770") ;; Aurora        / nord 12
   (setq nano-color-subtle     "#434C5E") ;; Polar Night 2 / nord  2
   (setq nano-color-faded      "#677691") ;;
+  ;; to allow for toggling of the themes.
+  (setq nano-theme-var "dark")
   )
 
 (nano-theme-set-dark)

--- a/nano-theme-light.el
+++ b/nano-theme-light.el
@@ -29,6 +29,8 @@
   (setq nano-color-popout     "#FFAB91") ;; Deep Orange / L200
   (setq nano-color-subtle     "#ECEFF1") ;; Blue Grey / L50
   (setq nano-color-faded      "#B0BEC5") ;; Blue Grey / L200
+  ;; to allow for toggling of the themes.
+  (setq nano-theme-var "light")
   )
 (nano-theme-set-light)
 

--- a/nano-theme.el
+++ b/nano-theme.el
@@ -765,4 +765,34 @@ function is a convenience wrapper used by `describe-package-1'."
   (nano-theme--hl-line)
   (nano-theme--company))
 
+(defun nano-refresh-theme ()
+  "Convenience function which refreshes the nano-theme.
+Calls \(nano-faces\) and \(nano-theme\) sequentially."
+  (interactive)
+  (progn
+    (nano-faces)
+    (nano-theme)))
+
+(defcustom nano-theme-var nil
+  "Variable which sets the default startup theme as light or dark.
+Also allows for toggling of the themes. Is set to 'light' by
+'nano-theme-light' and 'dark' by 'nano-theme-dark'.
+Defaults to nil."
+  :group 'nano
+  :type 'string)
+
+(defun nano-toggle-theme ()
+  "Function to interactively toggle between light and dark nano themes.
+Requires both to be loaded in order to work."
+  (interactive)
+  (cond ((string= nano-theme-var "light")
+         (progn (nano-theme-set-dark)
+                (nano-refresh-theme)
+                (setq nano-theme-var "dark")))
+         ((string= nano-theme-var "dark")
+         (progn (nano-theme-set-light)
+                (nano-refresh-theme)
+                (setq nano-theme-var "light")))
+         (t nil)))
+
 (provide 'nano-theme)

--- a/nano-theme.el
+++ b/nano-theme.el
@@ -32,6 +32,14 @@
 
 (require 'nano-faces)
 
+(defcustom nano-theme-var nil
+  "Variable which sets the default startup theme as light or dark.
+Also allows for toggling of the themes. Is set to 'light' by
+'nano-theme-light' and 'dark' by 'nano-theme-dark'.
+Defaults to nil."
+  :group 'nano
+  :type 'string)
+
 ;; When we set a face, we take care of removing any previous settings
 (defun set-face (face style)
   "Reset FACE and make it inherit STYLE."
@@ -773,13 +781,6 @@ Calls \(nano-faces\) and \(nano-theme\) sequentially."
     (nano-faces)
     (nano-theme)))
 
-(defcustom nano-theme-var nil
-  "Variable which sets the default startup theme as light or dark.
-Also allows for toggling of the themes. Is set to 'light' by
-'nano-theme-light' and 'dark' by 'nano-theme-dark'.
-Defaults to nil."
-  :group 'nano
-  :type 'string)
 
 (defun nano-toggle-theme ()
   "Function to interactively toggle between light and dark nano themes.


### PR DESCRIPTION
Fixes #26.

Adds two new functions: `(nano-refresh-theme)` and `(nano-toggle-theme)`, and one new variable `nano-theme-var`.

Calling `nano-toggle-theme` will switch the theme from light to dark, and vice versa. 
This does require you to also require both themes separately, otherwise the function fails. I put this in the docstring, but is probably a better way to do this, maybe adding the themes back into `nano-theme`?
