### PR TITLE
Fix byte-compilation errors

### DIFF
--- a/nano-writer.el
+++ b/nano-writer.el
@@ -16,6 +16,8 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ;; ---------------------------------------------------------------------
 (require 'org)
+(require 'org-indent)
+(require 'org-element)
 (require 'nano-base-colors)
 (require 'nano-faces)
 

--- a/nano-writer.el
+++ b/nano-writer.el
@@ -129,11 +129,12 @@ etc.
               #'writer-mode--compute-prefixes)
 
   ;; Numbering
-  (setq org-num-skip-unnumbered t)
-  (setq org-num-skip-footnotes t)
-  (setq org-num-max-level 2)
-  (setq org-num-face nil)
-  (org-num-mode)
-  (setq org-num-format-function 'writer-mode--num-format))
+  (when (require 'org-num nil t)
+    (setq org-num-skip-unnumbered t)
+    (setq org-num-skip-footnotes t)
+    (setq org-num-max-level 2)
+    (setq org-num-face nil)
+    (org-num-mode)
+    (setq org-num-format-function 'writer-mode--num-format)))
 
 (provide 'nano-writer)

--- a/nano-writer.el
+++ b/nano-writer.el
@@ -73,23 +73,23 @@ etc.
         (make-vector org-indent--deepest-level nil))
   (setq org-indent--text-line-prefixes
         (make-vector org-indent--deepest-level nil))
-        
+
   (let* ((min-indent 5)
          (indent (+ 1 (seq-max 
-                  (org-element-map
-                      (org-element-parse-buffer) 'headline
-                    #'(lambda (item)
-                        (org-element-property :level item))))))
+                       (org-element-map
+                           (org-element-parse-buffer) 'headline
+                         #'(lambda (item)
+                             (org-element-property :level item))))))
          (indent (max indent min-indent)))
     
-  (dotimes (n org-indent--deepest-level)
-    (aset org-indent--heading-line-prefixes n
-          (make-string
-           (min indent (max 0 (- indent 1 n))) ?\s))
-    (aset org-indent--inlinetask-line-prefixes n
-          (make-string indent ?\s))
-    (aset org-indent--text-line-prefixes n
-          (make-string indent ?\s)))))
+    (dotimes (n org-indent--deepest-level)
+      (aset org-indent--heading-line-prefixes n
+            (make-string
+             (min indent (max 0 (- indent 1 n))) ?\s))
+      (aset org-indent--inlinetask-line-prefixes n
+            (make-string indent ?\s))
+      (aset org-indent--text-line-prefixes n
+            (make-string indent ?\s)))))
 
 
 
@@ -107,7 +107,7 @@ etc.
                            :inherit 'nano-face-faded)
   (face-remap-add-relative 'org-document-title
                            :foreground nano-color-foreground
-                           :family "Roboto Slab" 
+                           :family "Roboto Slab"
                            :height 200
                            :weight 'medium)
   ;; hide title / author ... keywords
@@ -115,13 +115,13 @@ etc.
 
   ;; Header line
   (setq header-line-format nil)
-  
+
   ;; Layout
   (setq fill-column 72)
   (setq-default line-spacing 1)
 
   ;; Indentation
-  (setq org-startup-folded nil)  
+  (setq org-startup-folded nil)
   (org-indent-mode)
   (setq org-level-color-stars-only nil)
   (setq org-hide-leading-stars nil)

--- a/nano-writer.el
+++ b/nano-writer.el
@@ -94,7 +94,7 @@ etc.
             (make-string indent ?\s)))))
 
 
-
+;;;###autoload
 (define-derived-mode writer-mode org-mode "NΛNO writer"
 
   ;; Faces


### PR DESCRIPTION
Hello, I tried to build files in this repository and encountered some compilation errors.

- `org-num.el` seems to be a relatively new addition to org. It fails to build on Emacs 27.2, so I worked around it.
- Variables such as `org-indent--deepest-level` are unavailable until `org-indent.el` is loaded. The library should be explicitly loaded.
- You have to load `org-element.el` if you use functions such as `org-element-map`. They are not autoloaded.
- The trailing whitespace and misindentation are fixed. I'd suggest you turn on `aggressive-indent-mode` when you write elisp.

I also added the autoload magic to `writer-mode`, as the user don't have to load `nano-writer.el` until he/she uses the mode.