### PR TITLE
Correctly set per-window mode-line-format

### DIFF
--- a/nano-modeline.el
+++ b/nano-modeline.el
@@ -501,11 +501,12 @@ below or a buffer local variable 'no-mode-line'."
     (with-selected-window window
 	  (with-current-buffer (window-buffer window)
         (if (or (not (boundp 'no-mode-line)) (not no-mode-line))
-            (setq mode-line-format 
-                  (cond ((one-window-p t) (list ""))
-                        ((eq (window-in-direction 'below) (minibuffer-window)) (list ""))
-                        ((not (window-in-direction 'below)) (list ""))
-                        (t nil))))))))
+            (set-window-parameter window 'mode-line-format
+                                  (cond ((not mode-line-format) 'none)
+                                        ((one-window-p t 'visible) (list ""))
+                                        ((eq (window-in-direction 'below) (minibuffer-window)) (list ""))
+                                        ((not (window-in-direction 'below)) (list ""))
+                                        (t 'none))))))))
 
 (add-hook 'window-configuration-change-hook 'nano-modeline-update-windows)
 


### PR DESCRIPTION
This sets `mode-line-format` as a window parameter rather than the default `mode-line-format` variable and doesn't override buffers that have `mode-line-format` already set locally (as do most child-frame buffers).

This means if you open the same buffer one on top of the other, the one on top correctly hides the mode line; the current logic that sets it via `setq` automatically sets it at the buffer level, regardless of window configuration.

This also fixes an issue with packages that use `child-frames` as they will often set `mode-line-format` as a buffer local variable when creating the buffer contents. I've tested it with the frames created by `corfu` & `lsp-ui-doc` and both work as expected.