### PR TITLE
fix: toolbar and scroll bars still shown

### DIFF
--- a/nano-defaults.el
+++ b/nano-defaults.el
@@ -82,10 +82,10 @@
   (global-set-key (kbd "<mouse-5>") 'scroll-up-line))
 
 ;; No scroll bars
-(if (fboundp 'scroll-bar-mode) (scroll-bar-mode nil))
+(if (fboundp 'scroll-bar-mode) (set-scroll-bar-mode nil))
 
 ;; No toolbar
-(if (fboundp 'tool-bar-mode) (tool-bar-mode nil))
+(if (fboundp 'tool-bar-mode) (tool-bar-mode -1))
 
 ;; No menu bar
 (if (display-graphic-p)


### PR DESCRIPTION
Using the previous code. I still have toolbar and scroll bars shown.  This PR fixes the problem at least for me.

I also need to change the "No menu bar" to the code below. Otherwise, it wont work.

```diff
 
 ;; No menu bar
-(if (display-graphic-p)
-    (menu-bar-mode t) ;; When nil, focus problem on OSX
-  (menu-bar-mode -1))
+(menu-bar-mode -1)
 ```
 
 ```
 GNU Emacs 29.0.50 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.24.24, cairo version 1.16.0) of 2021-12-01
c13b49a110 (HEAD -> master, origin/master, origin/HEAD) 2 days ago update_autogen: Remove deprecated -I flag (Stefan Kangas)

OS: Debian GNU/Linux 11 (bullseye)
Kernel: Linux 5.10.0-9-amd64 x86_64
```
 