### PR TITLE
fix: frame title still shown

### DIFF
--- a/nano-defaults.el
+++ b/nano-defaults.el
@@ -30,7 +30,7 @@
 (setq initial-buffer-choice nil)
 
 ;; No frame title
-(setq frame-title-format nil)
+(setq frame-title-format " ")
 
 ;; No file dialog
 (setq use-file-dialog nil)


### PR DESCRIPTION
Hi.

`(setq frame-title-format nil)` and `(setq frame-title-format "")` doesn't work in my end. However setting it to `(setq frame-title-format " ")` works.

I think it because `""` also evaluates to `nil`