### PR TITLE
Fix for broken nano-help

### DIFF
--- a/nano-help.el
+++ b/nano-help.el
@@ -42,6 +42,11 @@
     (sit-for 30)))
 
 ;; Help screen
+
+;; FIX for quick-help.org not being found when using straight
+(setq pathfix (concat user-emacs-directory "straight/repos/nano-emacs"))
+(add-to-list 'load-path pathfix)
+
 (define-derived-mode nano-help-mode org-mode "Nano help mode")
 (define-key nano-help-mode-map (kbd "q") #'kill-current-buffer)
 (defun nano-help ()

--- a/nano-help.el
+++ b/nano-help.el
@@ -43,14 +43,11 @@
 
 ;; Help screen
 
-;; Fix for quick-help.org not being found when using straight
-(add-to-list 'load-path (concat user-emacs-directory "straight/repos/nano-emacs"))
-
 (define-derived-mode nano-help-mode org-mode "Nano help mode")
 (define-key nano-help-mode-map (kbd "q") #'kill-current-buffer)
 (defun nano-help ()
   (interactive)
-  (find-file-read-only (locate-file "quick-help.org" load-path))
+  (find-file-read-only (concat user-emacs-directory "straight/repos/nano-emacs/quick-help.org"))
   (nano-help-mode)
   (setq-local org-confirm-elisp-link-function nil))
 

--- a/nano-help.el
+++ b/nano-help.el
@@ -43,9 +43,8 @@
 
 ;; Help screen
 
-;; FIX for quick-help.org not being found when using straight
-(setq pathfix (concat user-emacs-directory "straight/repos/nano-emacs"))
-(add-to-list 'load-path pathfix)
+;; Fix for quick-help.org not being found when using straight
+(add-to-list 'load-path (concat user-emacs-directory "straight/repos/nano-emacs"))
 
 (define-derived-mode nano-help-mode org-mode "Nano help mode")
 (define-key nano-help-mode-map (kbd "q") #'kill-current-buffer)


### PR DESCRIPTION
Added a fix for `quick-help.org` not being found when using straight. Fixes the issue #110 
