### PR TITLE
fix usage on Emacs without GUI support

### DIFF
--- a/nano-layout.el
+++ b/nano-layout.el
@@ -58,9 +58,9 @@
       inhibit-startup-message t
       inhibit-startup-echo-area-message t
       initial-scratch-message nil)
-(if (fboundp 'tool-bar-mode) (tool-bar-mode nil))
+(when (fboundp 'tool-bar-mode) (tool-bar-mode nil))
 (tooltip-mode 0)
-(scroll-bar-mode nil)
+(when (fboundp 'scroll-bar-mode) (scroll-bar-mode nil))
 (menu-bar-mode 0)
 ;; (global-hl-line-mode 1)
 (setq x-underline-at-descent-line t)


### PR DESCRIPTION
It seems like scroll-bar-mode is not available in Emacs that was built
without GUI support, which means that nano-layout errors when
required.