### PR TITLE
do not assume presence of zsh

### DIFF
--- a/nano-defaults.el
+++ b/nano-defaults.el
@@ -157,7 +157,9 @@
       uniquify-ignore-buffers-re "^\\*")
 
 ;; Default shell in term
-(unless (eq system-type 'windows-nt)
+(unless
+    (or (eq system-type 'windows-nt)
+        (not (file-exists-p "/bin/zsh")))
   (setq-default shell-file-name "/bin/zsh")
   (setq explicit-shell-file-name "/bin/zsh"))
 


### PR DESCRIPTION
I have a non-NT system which does not have zsh installed.  nano should not attempt to set my default shall name to `zsh` unless that binary exists.