### PR TITLE
Fix minor bug in theme loading

### DIFF
--- a/nano-theme-dark.el
+++ b/nano-theme-dark.el
@@ -34,6 +34,4 @@
   (setq nano-theme-var "dark")
   )
 
-(nano-theme-set-dark)
-
 (provide 'nano-theme-dark)

--- a/nano-theme-light.el
+++ b/nano-theme-light.el
@@ -32,6 +32,5 @@
   ;; to allow for toggling of the themes.
   (setq nano-theme-var "light")
   )
-(nano-theme-set-light)
 
 (provide 'nano-theme-light)

--- a/nano-theme.el
+++ b/nano-theme.el
@@ -796,13 +796,10 @@ Calls \(nano-faces\) and \(nano-theme\) sequentially."
 Requires both to be loaded in order to work."
   (interactive)
   (cond ((string= nano-theme-var "light")
-         (progn (nano-theme-set-dark)
-                (nano-refresh-theme)
-                (setq nano-theme-var "dark")))
+         (nano-theme-set-dark))
          ((string= nano-theme-var "dark")
-         (progn (nano-theme-set-light)
-                (nano-refresh-theme)
-                (setq nano-theme-var "light")))
-         (t nil)))
+          (nano-theme-set-light))
+         (t nil))
+  (nano-refresh-theme))
 
 (provide 'nano-theme)

--- a/nano.el
+++ b/nano.el
@@ -34,11 +34,6 @@
 (add-to-list 'command-switch-alist '("-compact" . (lambda (args))))
 
 
-(cond
- ((member "-default" command-line-args) t)
- ((member "-dark" command-line-args) (require 'nano-theme-dark))
- (t (require 'nano-theme-light)))
-
 ;; Customize support for 'emacs -q' (Optional)
 ;; You can enable customizations by creating the nano-custom.el file
 ;; with e.g. `touch nano-custom.el` in the folder containing this file.
@@ -54,10 +49,15 @@
 
 ;; Theme
 (require 'nano-faces)
-(nano-faces)
-
 (require 'nano-theme)
-(nano-theme)
+(require 'nano-theme-dark)
+(require 'nano-theme-light)
+
+(cond
+ ((member "-default" command-line-args) t)
+ ((member "-dark" command-line-args) (nano-theme-set-dark))
+ (t (nano-theme-set-light)))
+(call-interactively 'nano-refresh-theme)
 
 ;; Nano default settings (optional)
 (require 'nano-defaults)


### PR DESCRIPTION
Currently, the files `nano-theme-*` are _only required_ based on command-line flags (e.g., specifying `-dark`, for instance, _requires_ `nano-theme-dark`). So one of the two `nano-theme-*` and its functions will remain unloaded. Now, when a user invokes `nano-toggle-theme` it will complain not knowing about the alternative `nano-theme-set-*` (i.e., if `nano-theme-dark` was loaded, then toggling does not know of `nano-theme-set-light` function.). This fix loads both themes (one commit changes the theme files to simply supply the functions, but not call them), but activates the appropriate theme based on command-line flags.