### PR TITLE
Remove windmove as conflicts with org-mode date value S-arrowkey manipulations

### DIFF
--- a/nano-defaults.el
+++ b/nano-defaults.el
@@ -92,9 +92,6 @@
     (menu-bar-mode t) ;; When nil, focus problem on OSX
   (menu-bar-mode -1))
 
-;; Navigate windows using shift+direction
-;; (windmove-default-keybindings)
-
 ;; Tab behavior
 ;; (setq tab-always-indent 'complete)
 ;; (global-company-mode)

--- a/nano-defaults.el
+++ b/nano-defaults.el
@@ -93,7 +93,7 @@
   (menu-bar-mode -1))
 
 ;; Navigate windows using shift+direction
-(windmove-default-keybindings)
+;; (windmove-default-keybindings)
 
 ;; Tab behavior
 ;; (setq tab-always-indent 'complete)


### PR DESCRIPTION
Windmove is built into Gnu Emacs but conflicts with org-mode standard behaviour in calendar popup and with cursor inside dates and does not allow dates to be incremented or decremented (or movement around individual days in popup calendar.

Conflicts doc is here: https://orgmode.org/manual/Conflicts.html

This PR removes windmove and returns S-arrow control back to dates. 