### PR TITLE
Use the defined strong colour instead of using the default

### DIFF
--- a/nano-faces.el
+++ b/nano-faces.el
@@ -203,10 +203,10 @@ background color that is barely perceptible."
                           :height (* nano-font-size 10))
   (if (display-graphic-p)
       (set-face-attribute 'nano-face-strong nil
-                          :foreground (face-foreground 'nano-face-default)
+                          :foreground nano-color-strong
                           :weight 'medium)
     (set-face-attribute 'nano-face-strong nil
-                        :foreground (face-foreground 'nano-face-default)
+                        :foreground nano-color-strong
                         :weight 'bold))
 
   (set-face-attribute 'nano-face-salient nil


### PR DESCRIPTION
In theme definitions, a colour was assigned to strong as seen bellow

```
(setq nano-color-critical   "#EBCB8B") ;; Aurora / nord 11
```

Unfortunately, strong didn't use this defined colour but the default instead

```
:foreground (face-foreground 'nano-face-default)
```

This commit fixes that by using the strong colour that is defined in themes.