### PR TITLE
Check if a face does not exists before setting it.

### DIFF
--- a/nano-theme.el
+++ b/nano-theme.el
@@ -43,12 +43,16 @@ Defaults to nil."
 ;; When we set a face, we take care of removing any previous settings
 (defun set-face (face style)
   "Reset FACE and make it inherit STYLE."
-  (set-face-attribute face nil
-                      :foreground 'unspecified :background 'unspecified
-                      :family     'unspecified :slant      'unspecified
-                      :weight     'unspecified :height     'unspecified
-                      :underline  'unspecified :overline   'unspecified
-                      :box        'unspecified :inherit    style))
+  (if (facep face)
+      (set-face-attribute face nil
+                          :foreground 'unspecified :background 'unspecified
+                          :family     'unspecified :slant      'unspecified
+                          :weight     'unspecified :height     'unspecified
+                          :underline  'unspecified :overline   'unspecified
+                          :box        'unspecified :inherit    style)
+    (message "NANO Warning: Face %s could not be set. It may not be defined."
+             face)))
+  
 
 
 (defun nano-theme--basics ()


### PR DESCRIPTION
Hi!
When using `find-file` in Emacs 29, an error message appears: `error "Invalid face" bookmark-menu-heading` 
This were reported at Issue #127 ( [link](https://github.com/rougier/nano-emacs/issues/127) ). 

As I commented there, I added a check on `set-face` before setting the face. It  just message a warning when the face does not exists, in this case, `bookmark-menu-heading`. Thus, the library is loaded completely despite not finding the face.

 Maybe, this is not the solution, but it may be useful for future versions, particularly, when new faces are modified.